### PR TITLE
Fix error of verify logs

### DIFF
--- a/distributed/exes/verifyClient.cc
+++ b/distributed/exes/verifyClient.cc
@@ -146,7 +146,7 @@ int verifyThread(strongstore::Client* client, int idx, int tLen, int wPer, int d
                    (t1.tv_usec - t0.tv_usec);
 
     fprintf(stderr, "%ld %ld.%06ld %ld.%06ld %ld %d %d\n", unverified_keys.size(),
-        t0.tv_sec, t0.tv_usec, t1.tv_sec, t1.tv_usec, latency, vs?1:0, 3);
+        t0.tv_sec, t0.tv_usec, t1.tv_sec, t1.tv_usec, latency, vs?0:1, 3);
     
     {
       boost::unique_lock<boost::shared_mutex> write(lck);


### PR DESCRIPTION
In `process_ycsb.py`, a flag represents whether an operation succeeds. It is processed as:
=1 : success
=0 : failure

`verifyClient.cc` outputs logs for two operations `Verify()` and `Commit()`
1. For `Commit()`, if status is REPLY_OK, then log `true`, which is **correct**.
2. For `Verify()`, if status is REPLY_OK, then log `false`, which is **wrong**.

This pull request fixes the error in situation 2.